### PR TITLE
URL Encode the UPN (Email Address)

### DIFF
--- a/resources/scripts/New-CKTAppRegistration.ps1
+++ b/resources/scripts/New-CKTAppRegistration.ps1
@@ -281,6 +281,7 @@ function New-CKTAppRegistration {
     if($AssignAppRoleToUser){
         Write-Host "[+] Granting app role assignment to $AssignAppRoleToUser "
         Write-Host "    [>>] Getting user's principal ID"
+        $AssignAppRoleToUser = [System.Web.HttpUtility]::UrlEncode($AssignAppRoleToUser)
         $params = @{
             "Method"  = "Get"
             "Uri"     = "https://graph.microsoft.com/v1.0/users/$AssignAppRoleToUser"


### PR DESCRIPTION
This just adds a single line to URL encode the user name parameter. Many default AAD Principal UPN's contain characters that need to be URL encoded before hitting this API: sean_outlook.com#EXT#@seanoutlook.onmicrosoft.com
Should be:
sean_outlook.com%23EXT%23%40seanoutlook.onmicrosoft.com Otherwise this deployment will fail.